### PR TITLE
Fixing override existing values

### DIFF
--- a/AutoNumber/CreateAutoNumber.cs
+++ b/AutoNumber/CreateAutoNumber.cs
@@ -112,7 +112,28 @@ namespace Celedon
 			};
 
 		    context.Trace("Create new plugin step");
-			context.OrganizationService.Create(newPluginStep);
+		    var sdkmessageprocessingstepid = context.OrganizationService.Create(newPluginStep);
+
+            // only add the image if the type is update, on create a value cannot be overridden
+		    if (target.GetAttributeValue<OptionSetValue>("cel_triggerevent").Value == 1)
+		    {
+		        context.Trace("Build new plugin step image");
+		        var newPluginStepImage = new Entity("sdkmessageprocessingstepimage")
+		        {
+		            Attributes = new AttributeCollection()
+		            {
+		                {"sdkmessageprocessingstepid", sdkmessageprocessingstepid.ToEntityReference("sdkmessageprocessingstep")},
+		                {"imagetype", 0.ToOptionSetValue()}, // PreImage
+		                {"messagepropertyname", "Target"},
+		                {"name", "Image"}, 
+		                {"entityalias", "Image"}, 
+		                {"attributes", target.GetAttributeValue<string>("cel_attributename")}, //Only incluce the one attribute we really need. 
+		            }
+		        };
+
+		        context.Trace("Create new plugin step image");
+		        context.OrganizationService.Create(newPluginStepImage);
+		    }
 		}
 	}
 }

--- a/AutoNumber/DeleteAutoNumber.cs
+++ b/AutoNumber/DeleteAutoNumber.cs
@@ -84,9 +84,20 @@ namespace Celedon
 			{
 				return;  
 			}
-			
-			// Delete plugin step
-			context.OrganizationService.Delete("sdkmessageprocessingstep", pluginStepList.First());
+
+            // Delete all images
+		    var images = context.OrganizationDataContext.CreateQuery("sdkmessageprocessingstepimage")
+		        .Where(s => s.GetAttributeValue<Guid>("sdkmessageprocessingstepid").Equals(pluginStepList.First()))
+		        .Select(s => s.GetAttributeValue<Guid>("sdkmessageprocessingstepimageid"))
+		        .ToList();
+
+		    foreach (var image in images)
+		    {
+		        context.OrganizationService.Delete("sdkmessageprocessingstepimage", image);
+            }
+
+            // Delete plugin step
+            context.OrganizationService.Delete("sdkmessageprocessingstep", pluginStepList.First());
 		}
 	}
 }

--- a/AutoNumber/GetNextAutoNumber.cs
+++ b/AutoNumber/GetNextAutoNumber.cs
@@ -107,7 +107,7 @@ namespace Celedon
 					continue;  // Continue, if this is a conditional optionset
 				}
 
-                if (context.PreImage.Contains(targetAttribute) && !string.IsNullOrWhiteSpace(context.PreImage.GetAttributeValue<string>(targetAttribute)))
+                if (triggerEvent == 1 && context.PreImage.Contains(targetAttribute) && !string.IsNullOrWhiteSpace(context.PreImage.GetAttributeValue<string>(targetAttribute)))
                 {
                     context.TracingService.Trace("Target attribute '{0}' is already populated. Continue, so we don't overwrite an existing value.", targetAttribute);
                     continue;  // Continue, so we don't overwrite an existing value

--- a/AutoNumber/GetNextAutoNumber.cs
+++ b/AutoNumber/GetNextAutoNumber.cs
@@ -107,9 +107,10 @@ namespace Celedon
 					continue;  // Continue, if this is a conditional optionset
 				}
 
-                if (target.Contains(targetAttribute) && !string.IsNullOrWhiteSpace(target.GetAttributeValue<string>(targetAttribute)))
-				{
-					continue;  // Continue, so we don't overwrite an existing value
+                if (context.PreImage.Contains(targetAttribute) && !string.IsNullOrWhiteSpace(context.PreImage.GetAttributeValue<string>(targetAttribute)))
+                {
+                    context.TracingService.Trace("Target attribute '{0}' is already populated. Continue, so we don't overwrite an existing value.", targetAttribute);
+                    continue;  // Continue, so we don't overwrite an existing value
 				}
 				#endregion
 


### PR DESCRIPTION
This commit fixes #19 

It creates a pre-image for the dynamically registered message steps and checks that pre-image before updateing the autonumber